### PR TITLE
Fix bug remove user_id field requiered

### DIFF
--- a/apps/assignments/serializers.py
+++ b/apps/assignments/serializers.py
@@ -1,14 +1,19 @@
 from rest_framework import serializers
 
-from apps.accounts.models import User
 from .models import Assignments
 
 
-class AssignmentsSerializer(serializers.ModelSerializer):
-    user_id = serializers.PrimaryKeyRelatedField(
-        queryset=User.objects.values_list('pk', flat=True))
-
+class AssignmentsCreateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Assignments
         exclude = ['user']
+        read_only_fields = ('id', 'created_at', 'updated_at')
+
+
+class AssignmentsRetrieveSerializer(serializers.ModelSerializer):
+    user_id = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = Assignments
+        fields = '__all__'
         read_only_fields = ('id', 'created_at', 'updated_at')

--- a/apps/assignments/tests/test_views.py
+++ b/apps/assignments/tests/test_views.py
@@ -63,7 +63,6 @@ class AssignmentsViewSetTestCase(TestCase):
     def test_create_assignment(self):
         url = reverse('assignments:assignments-list')
         data = {
-            'user_id': self.user.id,
             'title': 'New Assignment',
             'description': 'New Assignment Description',
             'due_date': '2021-01-01'
@@ -73,18 +72,6 @@ class AssignmentsViewSetTestCase(TestCase):
         self.assertEqual(Assignments.objects.count(), 1)
         self.assertEqual(Assignments.objects.first().title, 'New Assignment')
         self.assertEqual(Assignments.objects.first().description, 'New Assignment Description')
-
-    def test_cannot_create_assignment_for_other_user(self):
-        url = reverse('assignments:assignments-list')
-        data = {
-            'user_id': self.user_staff.id,
-            'title': 'New Assignment',
-            'description': 'New Assignment Description',
-            'due_date': '2021-01-01'
-        }
-        response = self.client.post(url, data, headers=self.headers)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(Assignments.objects.count(), 0)
 
     def test_retrieve_assignment(self):
         assignment = PendingAssignmentFactory.make_assignment_for_user(user=self.user)
@@ -99,7 +86,6 @@ class AssignmentsViewSetTestCase(TestCase):
         assignment = InProgressAssignmentFactory.make_assignment_for_user(user=self.user)
         url = reverse('assignments:assignments-detail', args=[assignment.id])
         data = {
-            'user_id': self.user_staff.id,
             'title': 'New Assignment',
             'description': 'New Assignment Description',
             'due_date': '2021-01-01',


### PR DESCRIPTION
## Description
It was an illogical case. It is not necessary to include the user_id in the payload for the POST request.
## Summary
- Remove user_id as a required field
- Create new serializers
- Remove unnecessary tests for the user_id requirement

